### PR TITLE
fix: tolerate bad markup

### DIFF
--- a/lib/abstractTree.js
+++ b/lib/abstractTree.js
@@ -31,6 +31,10 @@ const recurseNodeToExtractTree = (treebase, node) => {
   }
   owns.split(' ').forEach((id) => {
     const child = treebase.querySelector(`[data-owns-id="${id}"]`);
+    if (!child) {
+      console.warn('no child with data-owns-id', id);
+      return;
+    }
     const newnode = recurseNodeToExtractTree(treebase, child);
     newnode.parent = parent;
     parent.children.push(newnode);

--- a/lib/navigator.js
+++ b/lib/navigator.js
@@ -57,13 +57,14 @@ class navigator {
   }
 
   highlightSubtree(boolean, node) {
+    if (!node) return;
     if (boolean === true) {
       node.classList.add('is-highlight');
     }
     if (boolean === false) {
       node.classList.remove('is-highlight');
     }
-    if (!node.hasAttribute('data-owns')) return;
+    if (!node.getAttribute('data-owns')) return;
     node.getAttribute('data-owns').split(' ').forEach(id => this.highlightSubtree(boolean, this.node.querySelector(`[data-owns-id="${id}"]`)));
   }
 

--- a/test/index.html
+++ b/test/index.html
@@ -41,6 +41,8 @@
 
     <!-- test error catching -->
     <span role="tree" aria-label="bad tree"></span>
+    <span role="tree" data-owns aria-label="bad tree 2"></span>
+    <span role="tree" data-owns="notarget" aria-label="bad tree 3"></span>
 
     <script type="module">
       import { attachNavigator } from "/dist/aria-tree-walker.esm.js";

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,10 @@ test('catch errors', pageMacro, async (t, page) => {
     t.fail();
   });
   await page.goto('localhost:8080/test/');
+  await page.evaluate(() => {
+    document.querySelector('[aria-label="bad tree 2"]').focus();
+    document.querySelector('[aria-label="bad tree 3"]').focus();
+  });
   t.pass();
 });
 


### PR DESCRIPTION
Avoids throwing errors on a few more cases of bad markup.
* navigator.js
  * highlightSubtree: tolerate falsy nodes and falsy data-owns attributes
* abstractTree.js
  * recurseNodeToExtractTree: tolerate bad owns entries / falsy children
* test: add more bad markup tests that shouldn't throw errors

Fixes #36